### PR TITLE
feat: make 1GiB sector harder

### DIFF
--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -71,7 +71,7 @@ lazy_static! {
             (SECTOR_SIZE_8_MIB, 1),
             (SECTOR_SIZE_16_MIB, 1),
             (SECTOR_SIZE_512_MIB, 1),
-            (SECTOR_SIZE_1_GIB, 1),
+            (SECTOR_SIZE_1_GIB, 5),
             (SECTOR_SIZE_32_GIB, 10),
             (SECTOR_SIZE_64_GIB, 10),
         ]
@@ -88,6 +88,8 @@ lazy_static! {
             (SECTOR_SIZE_8_MIB, 2),
             (SECTOR_SIZE_16_MIB, 2),
             (SECTOR_SIZE_512_MIB, 2),
+            // When we try to set different number of layers, it fails (src/stacked/circuit/hash.rs)
+            // When try to set 11, it is killed on OOM
             (SECTOR_SIZE_1_GIB, 2),
             (SECTOR_SIZE_32_GIB, 11),
             (SECTOR_SIZE_64_GIB, 11),
@@ -108,7 +110,7 @@ lazy_static! {
             (SECTOR_SIZE_8_MIB, 2),
             (SECTOR_SIZE_16_MIB, 2),
             (SECTOR_SIZE_512_MIB, 2),
-            (SECTOR_SIZE_1_GIB, 2),
+            (SECTOR_SIZE_1_GIB, 6),
             (SECTOR_SIZE_32_GIB, 2349), // this gives 125,279,217 constraints, fitting in a single partition
             (SECTOR_SIZE_64_GIB, 2300), // this gives 129,887,900 constraints, fitting in a single partition
         ]
@@ -123,7 +125,8 @@ lazy_static! {
 pub(crate) const fn get_porep_interactive_minimum_challenges(sector_size: u64) -> usize {
     match sector_size {
         SECTOR_SIZE_2_KIB | SECTOR_SIZE_4_KIB | SECTOR_SIZE_16_KIB | SECTOR_SIZE_32_KIB
-        | SECTOR_SIZE_8_MIB | SECTOR_SIZE_16_MIB | SECTOR_SIZE_512_MIB | SECTOR_SIZE_1_GIB => 2,
+        | SECTOR_SIZE_8_MIB | SECTOR_SIZE_16_MIB | SECTOR_SIZE_512_MIB => 2,
+        SECTOR_SIZE_1_GIB => 69,
         SECTOR_SIZE_32_GIB | SECTOR_SIZE_64_GIB => 176,
         _ => panic!("invalid sector size"),
     }

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -124,7 +124,7 @@ pub(crate) const fn get_porep_interactive_minimum_challenges(sector_size: u64) -
     match sector_size {
         SECTOR_SIZE_2_KIB | SECTOR_SIZE_4_KIB | SECTOR_SIZE_16_KIB | SECTOR_SIZE_32_KIB
         | SECTOR_SIZE_8_MIB | SECTOR_SIZE_16_MIB | SECTOR_SIZE_512_MIB => 2,
-        SECTOR_SIZE_1_GIB => SECTOR_SIZE_32_GIB | SECTOR_SIZE_64_GIB => 176,
+        SECTOR_SIZE_1_GIB | SECTOR_SIZE_32_GIB | SECTOR_SIZE_64_GIB => 176,
         _ => panic!("invalid sector size"),
     }
 }

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -110,7 +110,7 @@ lazy_static! {
             (SECTOR_SIZE_8_MIB, 2),
             (SECTOR_SIZE_16_MIB, 2),
             (SECTOR_SIZE_512_MIB, 2),
-            (SECTOR_SIZE_1_GIB, 6),
+            (SECTOR_SIZE_1_GIB, 100),
             (SECTOR_SIZE_32_GIB, 2349), // this gives 125,279,217 constraints, fitting in a single partition
             (SECTOR_SIZE_64_GIB, 2300), // this gives 129,887,900 constraints, fitting in a single partition
         ]

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -71,7 +71,7 @@ lazy_static! {
             (SECTOR_SIZE_8_MIB, 1),
             (SECTOR_SIZE_16_MIB, 1),
             (SECTOR_SIZE_512_MIB, 1),
-            (SECTOR_SIZE_1_GIB, 5),
+            (SECTOR_SIZE_1_GIB, 10),
             (SECTOR_SIZE_32_GIB, 10),
             (SECTOR_SIZE_64_GIB, 10),
         ]
@@ -88,9 +88,7 @@ lazy_static! {
             (SECTOR_SIZE_8_MIB, 2),
             (SECTOR_SIZE_16_MIB, 2),
             (SECTOR_SIZE_512_MIB, 2),
-            // When we try to set different number of layers, it fails (src/stacked/circuit/hash.rs)
-            // When try to set 11, it is killed on OOM
-            (SECTOR_SIZE_1_GIB, 2),
+            (SECTOR_SIZE_1_GIB, 11),
             (SECTOR_SIZE_32_GIB, 11),
             (SECTOR_SIZE_64_GIB, 11),
         ]
@@ -110,7 +108,7 @@ lazy_static! {
             (SECTOR_SIZE_8_MIB, 2),
             (SECTOR_SIZE_16_MIB, 2),
             (SECTOR_SIZE_512_MIB, 2),
-            (SECTOR_SIZE_1_GIB, 100),
+            (SECTOR_SIZE_1_GIB, 2349),
             (SECTOR_SIZE_32_GIB, 2349), // this gives 125,279,217 constraints, fitting in a single partition
             (SECTOR_SIZE_64_GIB, 2300), // this gives 129,887,900 constraints, fitting in a single partition
         ]
@@ -126,8 +124,7 @@ pub(crate) const fn get_porep_interactive_minimum_challenges(sector_size: u64) -
     match sector_size {
         SECTOR_SIZE_2_KIB | SECTOR_SIZE_4_KIB | SECTOR_SIZE_16_KIB | SECTOR_SIZE_32_KIB
         | SECTOR_SIZE_8_MIB | SECTOR_SIZE_16_MIB | SECTOR_SIZE_512_MIB => 2,
-        SECTOR_SIZE_1_GIB => 69,
-        SECTOR_SIZE_32_GIB | SECTOR_SIZE_64_GIB => 176,
+        SECTOR_SIZE_1_GIB => SECTOR_SIZE_32_GIB | SECTOR_SIZE_64_GIB => 176,
         _ => panic!("invalid sector size"),
     }
 }


### PR DESCRIPTION
Adjusts 1GiB sector's security params to the production ones.

Machine: Azure VM, Standard NV18ads A10 v5 (18 vcpus, 220 GiB memory, 1/2 Nvidia A10).

PreCommit: 5 minutes
ProveCommit: 17minutes
 
PreCommit + ProveCommit on 220GiB RAM + 128GiB SWAP machine with GPU:
22minutes
MAX RAM usage: 86.7%
Max VSZ: 268GiB
Max RSS: 197 GiB

PoSt Run on 2349 sectors per partition, 1 GiB Sectors:
total time: 10min
Max RAM Usage: 58.8%
Max VSZ: 155 GB
Max RSZ: 133 GB
